### PR TITLE
Add new feature to add the repo name as topic appendix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.envrc
+.password

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 FROM alpine:3.23.2
 
 LABEL maintainer="Michael Oberdorf IT-Consulting <info@oberdorf-itc.de>"
-LABEL site.local.program.version="1.0.3"
+LABEL site.local.program.version="1.1.0"
 
 ENV MQTT_SERVER=localhost \
     MQTT_PORT=1883 \
     MQTT_TLS_enabled=false \
     MQTT_TLS_no_hostname_validation=false \
     MQTT_RETAIN=false \
-    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+    MQTT_TOPIC_REPO_EXTENSION=false
 
 RUN apk upgrade --available --no-cache --update \
     && apk add --no-cache --update \

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 cybcon
+Copyright (c) 2025-2026 Michael Oberdorf IT-Consulting
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Container image: [DockerHub](https://hub.docker.com/r/oitc/dockerhubstats2mqtt)
 
 # Supported tags and respective `Dockerfile` links
 
-* [`latest`, `1.0.3`](https://github.com/cybcon/docker.dockerhubstats2mqtt/blob/v1.0.3/Dockerfile)
+* [`latest`, `1.1.0`](https://github.com/cybcon/docker.dockerhubstats2mqtt/blob/v1.1.0/Dockerfile)
+* [`1.0.3`](https://github.com/cybcon/docker.dockerhubstats2mqtt/blob/v1.0.3/Dockerfile)
 * [`1.0.2`](https://github.com/cybcon/docker.dockerhubstats2mqtt/blob/v1.0.2/Dockerfile)
 * [`1.0.1`](https://github.com/cybcon/docker.dockerhubstats2mqtt/blob/v1.0.1/Dockerfile)
 * [`1.0.0`](https://github.com/cybcon/docker.dockerhubstats2mqtt/blob/v1.0.0/Dockerfile)
@@ -55,6 +56,7 @@ The container grab the configuration via environment variables.
 | `MQTT_TOPIC` | The MQTT topic to send the docker hub statistics to | **MANDATORY** | |
 | `MQTT_RETAIN`| Set the retain flag when publishing the docker hub statistics to MQTT topic | **OPTIONAL** | `false` |
 | `REPOSITORIES` | A whitespace separated list of docker hub repositories where to collect the statistics | **MANDATORY** | |
+| `MQTT_TOPIC_REPO_EXTENSION` | Use the docker hub repository name as MQTT topic appendix | **OPTIONAL** | `false` |
 
 # Docker compose configuration
 
@@ -81,7 +83,7 @@ I would appreciate a small donation to support the further development of my ope
 
 # License
 
-Copyright (c) 2025 Michael Oberdorf IT-Consulting
+Copyright (c) 2025-2026 Michael Oberdorf IT-Consulting
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       MQTT_TOPIC: com/docker/hub/repositories/metrics
       REPOSITORIES: oitc/dockerhubstats2mqtt oitc/modbus-server
       REQUESTS_CA_BUNDLE: /etc/ssl/certs/ca-certificates.crt
+      MQTT_TOPIC_REPO_EXTENSION: false
     secrets:
       - mqtt_password
     tmpfs:

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -7,13 +7,13 @@
 # Author: Michael Oberdorf
 # Date:   2025-03-11
 # Last changed by: Michael Oberdorf
-# Last changed at: 2025-12-28
+# Last changed at: 2026-01-10
 ##############################################################################
 
 #-----------------------------------------------------------------------------
 # Global configuration
 #-----------------------------------------------------------------------------
-VERSION="1.0.3"
+VERSION="1.1.0"
 CACERT_SYSTEM_PATH='/etc/ssl/certs'
 
 # Set default values
@@ -31,6 +31,9 @@ if [ -z "${MQTT_TLS_no_hostname_validation}" ]; then
 fi
 if [ -z "${MQTT_RETAIN}" ]; then
   MQTT_RETAIN='false'
+fi
+if [ -z "${MQTT_TOPIC_REPO_EXTENSION}" ]; then
+  MQTT_TOPIC_REPO_EXTENSION='false'
 fi
 MQTT_PASSWORD=''
 
@@ -163,6 +166,13 @@ function validate_input_parameters {
     echo "ERROR: REPOSITORIES not defined. This parameter is mandatory!" >&2
     exit 1
   fi
+
+  if [ -z "$(validate_boolean ${MQTT_TOPIC_REPO_EXTENSION})" ]; then
+    echo "ERROR: Environment variable 'MQTT_TOPIC_REPO_EXTENSION' needs to be 'true' or 'false' (but is ${MQTT_TOPIC_REPO_EXTENSION})!" >&2
+    exit 1
+  else
+    MQTT_TOPIC_REPO_EXTENSION=$(validate_boolean ${MQTT_TOPIC_REPO_EXTENSION})
+  fi
 }
 
 #-----------------------------------------------------------------------------
@@ -187,9 +197,12 @@ function get_dockerhub_repository_statistics {
 #-----------------------------------------------------------------------------
 # publish_result
 # @desc: connect to MQTT server and publish the given information
+# @param: string, repository name
 # @param: string, data to publish to MQTT
 #-----------------------------------------------------------------------------
 function publish_result {
+  repo="${1}"
+  shift
   data="${@}"
 
   CREDENTIALS=''
@@ -199,6 +212,11 @@ function publish_result {
   RETAIN=''
   if [ "${MQTT_RETAIN}" == "true" ]; then
     RETAIN='--retain'
+  fi
+
+  mqtt_topic=${MQTT_TOPIC}
+  if [ "${MQTT_TOPIC_REPO_EXTENSION}" == "true" ]; then
+    mqtt_topic=$(echo "${MQTT_TOPIC}/${repo}" | sed -e 's%//%/%g')
   fi
 
   TLS=''
@@ -223,7 +241,7 @@ function publish_result {
     TLS="${INSECURE} ${CACERT} --tls-version tlsv1.2"
   fi
 
-  echo "${data}" |  mosquitto_pub --host ${MQTT_SERVER} --port ${MQTT_PORT} ${CREDENTIALS} --topic ${MQTT_TOPIC} ${TLS} ${RETAIN} --stdin-file
+  echo "${data}" |  mosquitto_pub --host ${MQTT_SERVER} --port ${MQTT_PORT} ${CREDENTIALS} --topic ${mqtt_topic} ${TLS} ${RETAIN} --stdin-file
 }
 
 
@@ -239,7 +257,7 @@ for repository in ${REPOSITORIES}
 do
   echo "Get statistics of: ${repository}"
   result=$(get_dockerhub_repository_statistics ${repository})
-  publish_result "${result}"
+  publish_result ${repository} "${result}"
 done
 
 echo "Dockerhub repository statistics collector v${VERSION} stopped"


### PR DESCRIPTION
# New Feature
* Adding new optional boolean parameter `MQTT_TOPIC_REPO_EXTENSION` to add the docker hub repository name as an appendix to the base `MQTT_TOPIC` path.